### PR TITLE
Fix FeederDemoCS compilation errors

### DIFF
--- a/SDK/c#/FeederDemoCS/FeederDemoCS.csproj
+++ b/SDK/c#/FeederDemoCS/FeederDemoCS.csproj
@@ -10,7 +10,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>FeederDemoCS</RootNamespace>
     <AssemblyName>FeederDemoCS</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <PublishUrl>publish\</PublishUrl>
     <Install>true</Install>

--- a/SDK/c#/FeederDemoCS/app.config
+++ b/SDK/c#/FeederDemoCS/app.config
@@ -1,3 +1,3 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
-<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5.2"/></startup></configuration>
+<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.8"/></startup></configuration>


### PR DESCRIPTION
Needed to raise FeederDemoCS .NET framework target version to 4.8 as well, since it was done for one its dependency, the vjoy interface wrapper

Otherwise the demo doesn't compile anymore